### PR TITLE
Fixed package name "appengine"

### DIFF
--- a/examples/appengine/app.go
+++ b/examples/appengine/app.go
@@ -23,11 +23,11 @@ import (
 
 	"github.com/garyburd/go-oauth/oauth"
 
-	"appengine"
-	"appengine/datastore"
-	"appengine/memcache"
-	"appengine/urlfetch"
-	"appengine/user"
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/datastore"
+	"google.golang.org/appengine/memcache"
+	"google.golang.org/appengine/urlfetch"
+	"google.golang.org/appengine/user"
 )
 
 var oauthClient = oauth.Client{


### PR DESCRIPTION
Please replace invalid package `appengine` to `google.golang.org/appengine` if passible.

Package management tools (such as [glide](https://github.com/Masterminds/glide)) outputs warnings.