### PR TITLE
Fix broken Login with Twitter image url

### DIFF
--- a/examples/twitter/main.go
+++ b/examples/twitter/main.go
@@ -256,7 +256,7 @@ var (
 </head>
 <body>
 <a href="/authorize">Authorize</a> or
-<a href="/signin"><img src="http://a0.twimg.com/images/dev/buttons/sign-in-with-twitter-d.png"></a>
+<a href="/signin"><img src="http://g.twimg.com/dev/sites/default/files/images_documentation/sign-in-with-twitter-gray.png"></a>
 </body>
 </html>`))
 


### PR DESCRIPTION
The "Login with Twitter" image in the Twitter Oauth example points to a missing image. This pull request updates the image URL to the latest official Twitter image.

Before:
<img width="283" alt="127_0_0_1_8080" src="https://cloud.githubusercontent.com/assets/349595/14466366/89073ef4-00a4-11e6-96d8-3a718a80bd87.png">

After:
<img width="493" alt="127_0_0_1_8080" src="https://cloud.githubusercontent.com/assets/349595/14466391/a22798ca-00a4-11e6-9a66-8325b2798adc.png">