### PR TITLE
Send verifier and callback in auth header

### DIFF
--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -291,13 +291,22 @@ type Client struct {
 	PrivateKey *rsa.PrivateKey
 }
 
+type request struct {
+	credentials *Credentials
+	method      string
+	u           *url.URL
+	form        url.Values
+	verifier    string
+	callbackURL string
+}
+
 var testHook = func(map[string]string) {}
 
 // oauthParams returns the OAuth request parameters for the given credentials,
 // method, URL and application params. See
 // http://tools.ietf.org/html/rfc5849#section-3.4 for more information about
 // signatures.
-func (c *Client) oauthParams(credentials *Credentials, method string, u *url.URL, form url.Values) (map[string]string, error) {
+func (c *Client) oauthParams(r *request) (map[string]string, error) {
 	oauthParams := map[string]string{
 		"oauth_consumer_key":     c.Credentials.Token,
 		"oauth_signature_method": c.SignatureMethod.String(),
@@ -309,8 +318,16 @@ func (c *Client) oauthParams(credentials *Credentials, method string, u *url.URL
 		oauthParams["oauth_nonce"] = nonce()
 	}
 
-	if credentials != nil {
-		oauthParams["oauth_token"] = credentials.Token
+	if r.credentials != nil {
+		oauthParams["oauth_token"] = r.credentials.Token
+	}
+
+	if r.verifier != "" {
+		oauthParams["oauth_verifier"] = r.verifier
+	}
+
+	if r.callbackURL != "" {
+		oauthParams["oauth_callback"] = r.callbackURL
 	}
 
 	testHook(oauthParams)
@@ -321,18 +338,18 @@ func (c *Client) oauthParams(credentials *Credentials, method string, u *url.URL
 	case HMACSHA1:
 		key := encode(c.Credentials.Secret, false)
 		key = append(key, '&')
-		if credentials != nil {
-			key = append(key, encode(credentials.Secret, false)...)
+		if r.credentials != nil {
+			key = append(key, encode(r.credentials.Secret, false)...)
 		}
 		h := hmac.New(sha1.New, key)
-		writeBaseString(h, method, u, form, oauthParams)
+		writeBaseString(h, r.method, r.u, r.form, oauthParams)
 		signature = base64.StdEncoding.EncodeToString(h.Sum(key[:0]))
 	case RSASHA1:
 		if c.PrivateKey == nil {
 			return nil, errors.New("oauth: private key not set")
 		}
 		h := sha1.New()
-		writeBaseString(h, method, u, form, oauthParams)
+		writeBaseString(h, r.method, r.u, r.form, oauthParams)
 		rawSignature, err := rsa.SignPKCS1v15(rand.Reader, c.PrivateKey, crypto.SHA1, h.Sum(nil))
 		if err != nil {
 			return nil, err
@@ -341,8 +358,8 @@ func (c *Client) oauthParams(credentials *Credentials, method string, u *url.URL
 	case PLAINTEXT:
 		rawSignature := encode(c.Credentials.Secret, false)
 		rawSignature = append(rawSignature, '&')
-		if credentials != nil {
-			rawSignature = append(rawSignature, encode(credentials.Secret, false)...)
+		if r.credentials != nil {
+			rawSignature = append(rawSignature, encode(r.credentials.Secret, false)...)
 		}
 		signature = string(rawSignature)
 	default:
@@ -368,7 +385,7 @@ func (c *Client) SignForm(credentials *Credentials, method, urlStr string, form 
 	case u.RawQuery != "":
 		return errors.New("oauth: urlStr argument to SignForm must not include a query string")
 	}
-	p, err := c.oauthParams(credentials, method, u, form)
+	p, err := c.oauthParams(&request{credentials: credentials, method: method, u: u, form: form})
 	if err != nil {
 		return err
 	}
@@ -382,7 +399,7 @@ func (c *Client) SignForm(credentials *Credentials, method, urlStr string, form 
 func (c *Client) SignParam(credentials *Credentials, method, urlStr string, params url.Values) {
 	u, _ := url.Parse(urlStr)
 	u.RawQuery = ""
-	p, _ := c.oauthParams(credentials, method, u, params)
+	p, _ := c.oauthParams(&request{credentials: credentials, method: method, u: u, form: params})
 	for k, v := range p {
 		params.Set(k, v)
 	}
@@ -396,10 +413,12 @@ var oauthKeys = []string{
 	"oauth_timestamp",
 	"oauth_token",
 	"oauth_version",
+	"oauth_callback",
+	"oauth_verifier",
 }
 
-func (c *Client) authorizationHeader(credentials *Credentials, method string, u *url.URL, params url.Values) (string, error) {
-	p, err := c.oauthParams(credentials, method, u, params)
+func (c *Client) authorizationHeader(r *request) (string, error) {
+	p, err := c.oauthParams(r)
 	if err != nil {
 		return "", err
 	}
@@ -428,7 +447,7 @@ func (c *Client) authorizationHeader(credentials *Credentials, method string, u 
 func (c *Client) AuthorizationHeader(credentials *Credentials, method string, u *url.URL, params url.Values) string {
 	// Signing a request can return an error. This method is deprecated because
 	// this method does not return an error.
-	v, _ := c.authorizationHeader(credentials, method, u, params)
+	v, _ := c.authorizationHeader(&request{credentials: credentials, method: method, u: u, form: params})
 	return v
 }
 
@@ -436,8 +455,8 @@ func (c *Client) AuthorizationHeader(credentials *Credentials, method string, u 
 //
 // See http://tools.ietf.org/html/rfc5849#section-3.5.1 for information about
 // transmitting OAuth parameters in an HTTP request header.
-func (c *Client) SetAuthorizationHeader(header http.Header, credentials *Credentials, method string, u *url.URL, params url.Values) error {
-	v, err := c.authorizationHeader(credentials, method, u, params)
+func (c *Client) SetAuthorizationHeader(header http.Header, credentials *Credentials, method string, u *url.URL, form url.Values) error {
+	v, err := c.authorizationHeader(&request{credentials: credentials, method: method, u: u, form: form})
 	if err != nil {
 		return err
 	}
@@ -467,8 +486,8 @@ func (c *Client) Get(client *http.Client, credentials *Credentials, urlStr strin
 	return client.Do(req)
 }
 
-func (c *Client) do(client *http.Client, method string, credentials *Credentials, urlStr string, form url.Values) (*http.Response, error) {
-	req, err := http.NewRequest(method, urlStr, strings.NewReader(form.Encode()))
+func (c *Client) do(client *http.Client, urlStr string, r *request) (*http.Response, error) {
+	req, err := http.NewRequest(r.method, urlStr, strings.NewReader(r.form.Encode()))
 	if err != nil {
 		return nil, err
 	}
@@ -476,9 +495,13 @@ func (c *Client) do(client *http.Client, method string, credentials *Credentials
 		req.Header[k] = v
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	if err := c.SetAuthorizationHeader(req.Header, credentials, method, req.URL, form); err != nil {
+
+	r.u = req.URL
+	auth, err := c.authorizationHeader(r)
+	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Authorization", auth)
 	if client == nil {
 		client = http.DefaultClient
 	}
@@ -487,21 +510,22 @@ func (c *Client) do(client *http.Client, method string, credentials *Credentials
 
 // Post issues a POST with the specified form.
 func (c *Client) Post(client *http.Client, credentials *Credentials, urlStr string, form url.Values) (*http.Response, error) {
-	return c.do(client, "POST", credentials, urlStr, form)
+	return c.do(client, urlStr, &request{method: "POST", credentials: credentials, form: form})
 }
 
 // Delete issues a DELETE with the specified form.
 func (c *Client) Delete(client *http.Client, credentials *Credentials, urlStr string, form url.Values) (*http.Response, error) {
-	return c.do(client, "DELETE", credentials, urlStr, form)
+	return c.do(client, urlStr, &request{method: "DELETE", credentials: credentials, form: form})
 }
 
 // Put issues a PUT with the specified form.
 func (c *Client) Put(client *http.Client, credentials *Credentials, urlStr string, form url.Values) (*http.Response, error) {
-	return c.do(client, "PUT", credentials, urlStr, form)
+	return c.do(client, urlStr, &request{method: "PUT", credentials: credentials, form: form})
 }
 
-func (c *Client) requestCredentials(client *http.Client, credentials *Credentials, urlStr string, form url.Values) (*Credentials, url.Values, error) {
-	resp, err := c.Post(client, credentials, urlStr, form)
+func (c *Client) requestCredentials(client *http.Client, u string, r *request) (*Credentials, url.Values, error) {
+	r.method = "POST"
+	resp, err := c.do(client, u, r)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -532,14 +556,7 @@ func (c *Client) requestCredentials(client *http.Client, credentials *Credential
 // See http://tools.ietf.org/html/rfc5849#section-2.1 for information about
 // temporary credentials.
 func (c *Client) RequestTemporaryCredentials(client *http.Client, callbackURL string, additionalParams url.Values) (*Credentials, error) {
-	params := make(url.Values)
-	for k, vs := range additionalParams {
-		params[k] = vs
-	}
-	if callbackURL != "" {
-		params.Set("oauth_callback", callbackURL)
-	}
-	credentials, _, err := c.requestCredentials(client, nil, c.TemporaryCredentialRequestURI, params)
+	credentials, _, err := c.requestCredentials(client, c.TemporaryCredentialRequestURI, &request{form: additionalParams, callbackURL: callbackURL})
 	return credentials, err
 }
 
@@ -547,29 +564,17 @@ func (c *Client) RequestTemporaryCredentials(client *http.Client, callbackURL st
 // http://tools.ietf.org/html/rfc5849#section-2.3 for information about token
 // credentials.
 func (c *Client) RequestToken(client *http.Client, temporaryCredentials *Credentials, verifier string) (*Credentials, url.Values, error) {
-	params := make(url.Values)
-	if verifier != "" {
-		params.Set("oauth_verifier", verifier)
-	}
-	credentials, vals, err := c.requestCredentials(client, temporaryCredentials, c.TokenRequestURI, params)
-	if err != nil {
-		return nil, nil, err
-	}
-	return credentials, vals, nil
+	return c.requestCredentials(client, c.TokenRequestURI, &request{credentials: temporaryCredentials, verifier: verifier})
 }
 
 // RequestTokenXAuth requests token credentials from the server using the xAuth protocol.
 // See https://dev.twitter.com/oauth/xauth for information on xAuth.
 func (c *Client) RequestTokenXAuth(client *http.Client, temporaryCredentials *Credentials, user, password string) (*Credentials, url.Values, error) {
-	params := make(url.Values)
-	params.Set("x_auth_mode", "client_auth")
-	params.Set("x_auth_username", user)
-	params.Set("x_auth_password", password)
-	credentials, vals, err := c.requestCredentials(client, temporaryCredentials, c.TokenRequestURI, params)
-	if err != nil {
-		return nil, nil, err
-	}
-	return credentials, vals, nil
+	form := make(url.Values)
+	form.Set("x_auth_mode", "client_auth")
+	form.Set("x_auth_username", user)
+	form.Set("x_auth_password", password)
+	return c.requestCredentials(client, c.TokenRequestURI, &request{credentials: temporaryCredentials, form: form})
 }
 
 // AuthorizationURL returns the URL for resource owner authorization. See

--- a/oauth/oauth_test.go
+++ b/oauth/oauth_test.go
@@ -33,7 +33,7 @@ func parseURL(urlStr string) *url.URL {
 var oauthTests = []struct {
 	method    string
 	url       *url.URL
-	appParams url.Values
+	form      url.Values
 	nonce     string
 	timestamp string
 
@@ -49,7 +49,7 @@ var oauthTests = []struct {
 		// Simple example from Twitter OAuth tool
 		method:            "GET",
 		url:               parseURL("https://api.twitter.com/1/"),
-		appParams:         url.Values{"page": {"10"}},
+		form:              url.Values{"page": {"10"}},
 		nonce:             "8067e8abc6bdca2006818132445c8f4c",
 		timestamp:         "1355795903",
 		clientCredentials: Credentials{"kMViZR2MHk2mM7hUNVw9A", "56Fgl58yOfqXOhHXX0ybvOmSnPQFvR2miYmm30A"},
@@ -61,7 +61,7 @@ var oauthTests = []struct {
 		// Test case and port insensitivity.
 		method:            "GeT",
 		url:               parseURL("https://apI.twItter.com:443/1/"),
-		appParams:         url.Values{"page": {"10"}},
+		form:              url.Values{"page": {"10"}},
 		nonce:             "8067e8abc6bdca2006818132445c8f4c",
 		timestamp:         "1355795903",
 		clientCredentials: Credentials{"kMViZR2MHk2mM7hUNVw9A", "56Fgl58yOfqXOhHXX0ybvOmSnPQFvR2miYmm30A"},
@@ -73,7 +73,7 @@ var oauthTests = []struct {
 		// Example generated using the Netflix OAuth tool.
 		method:            "GET",
 		url:               parseURL("http://api-public.netflix.com/catalog/titles"),
-		appParams:         url.Values{"term": {"Dark Knight"}, "count": {"2"}},
+		form:              url.Values{"term": {"Dark Knight"}, "count": {"2"}},
 		nonce:             "1234",
 		timestamp:         "1355850443",
 		clientCredentials: Credentials{"apiKey001", "sharedSecret002"},
@@ -85,7 +85,7 @@ var oauthTests = []struct {
 		// Special characters in form values.
 		method:            "GET",
 		url:               parseURL("http://PHOTOS.example.net:8001/Photos"),
-		appParams:         url.Values{"photo size": {"300%"}, "title": {"Back of $100 Dollars Bill"}},
+		form:              url.Values{"photo size": {"300%"}, "title": {"Back of $100 Dollars Bill"}},
 		nonce:             "kllo~9940~pd9333jh",
 		timestamp:         "1191242096",
 		clientCredentials: Credentials{"dpf43f3++p+#2l4k3l03", "secret01"},
@@ -97,7 +97,7 @@ var oauthTests = []struct {
 		// Special characters in path, multiple values for same key in form.
 		method:            "GET",
 		url:               parseURL("http://EXAMPLE.COM:80/Space%20Craft"),
-		appParams:         url.Values{"name": {"value", "value"}},
+		form:              url.Values{"name": {"value", "value"}},
 		nonce:             "Ix4U1Ei3RFL",
 		timestamp:         "1327384901",
 		clientCredentials: Credentials{"abcd", "efgh"},
@@ -109,7 +109,7 @@ var oauthTests = []struct {
 		// Query string in URL.
 		method:            "GET",
 		url:               parseURL("http://EXAMPLE.COM:80/Space%20Craft?name=value"),
-		appParams:         url.Values{"name": {"value"}},
+		form:              url.Values{"name": {"value"}},
 		nonce:             "Ix4U1Ei3RFL",
 		timestamp:         "1327384901",
 		clientCredentials: Credentials{"abcd", "efgh"},
@@ -121,7 +121,7 @@ var oauthTests = []struct {
 		// "/" in form value.
 		method:            "POST",
 		url:               parseURL("https://stream.twitter.com/1.1/statuses/filter.json"),
-		appParams:         url.Values{"track": {"example.com/abcd"}},
+		form:              url.Values{"track": {"example.com/abcd"}},
 		nonce:             "bf2cb6d611e59f99103238fc9a3bb8d8",
 		timestamp:         "1362434376",
 		clientCredentials: Credentials{"consumer_key", "consumer_secret"},
@@ -133,7 +133,7 @@ var oauthTests = []struct {
 		// "/" in query string
 		method:            "POST",
 		url:               parseURL("https://stream.twitter.com/1.1/statuses/filter.json?track=example.com/query"),
-		appParams:         url.Values{},
+		form:              url.Values{},
 		nonce:             "884275759fbab914654b50ae643c563a",
 		timestamp:         "1362435218",
 		clientCredentials: Credentials{"consumer_key", "consumer_secret"},
@@ -145,7 +145,7 @@ var oauthTests = []struct {
 		// QuickBooks query string
 		method:            "GET",
 		url:               parseURL("https://qb.sbfinance.intuit.com/v3/company/1273852765/query"),
-		appParams:         url.Values{"query": {"select * from account"}},
+		form:              url.Values{"query": {"select * from account"}},
 		nonce:             "12345678",
 		timestamp:         "1409876517",
 		clientCredentials: Credentials{"consumer_key", "consumer_secret"},
@@ -167,7 +167,7 @@ var oauthTests = []struct {
 		signatureMethod:   RSASHA1,
 		method:            "GET",
 		url:               parseURL("http://term.ie/oauth/example/echo_api.php"),
-		appParams:         url.Values{"method": {"foo%20bar"}, "bar": {"baz"}},
+		form:              url.Values{"method": {"foo%20bar"}, "bar": {"baz"}},
 		nonce:             "a7da4d14579d61886be9d596d1a6a720",
 		timestamp:         "1420240290",
 		clientCredentials: Credentials{Token: "key"},
@@ -192,7 +192,7 @@ func TestBaseString(t *testing.T) {
 			"oauth_version":          "1.0",
 		}
 		var buf bytes.Buffer
-		writeBaseString(&buf, ot.method, ot.url, ot.appParams, oauthParams)
+		writeBaseString(&buf, ot.method, ot.url, ot.form, oauthParams)
 		base := buf.String()
 		if base != ot.base {
 			t.Errorf("base string for %s %s\n    = %q,\n want %q", ot.method, ot.url, base, ot.base)
@@ -239,13 +239,13 @@ func TestAuthorizationHeader(t *testing.T) {
 			}
 		}
 		c := Client{Credentials: ot.clientCredentials, SignatureMethod: ot.signatureMethod, PrivateKey: privateKey}
-		header, err := c.authorizationHeader(&ot.credentials, ot.method, ot.url, ot.appParams)
+		header, err := c.authorizationHeader(&request{credentials: &ot.credentials, method: ot.method, u: ot.url, form: ot.form})
 		if err != nil {
-			t.Errorf("authorizationHeader(&cred, %q, %q, %v) returned error %v", ot.method, ot.url.String(), ot.appParams, err)
+			t.Errorf("authorizationHeader(&cred, %q, %q, %v) returned error %v", ot.method, ot.url.String(), ot.form, err)
 			continue
 		}
 		if header != ot.header {
-			t.Errorf("authorizationHeader(&cred, %q, %q, %v) =\n      %s\nwant: %s", ot.method, ot.url.String(), ot.appParams, header, ot.header)
+			t.Errorf("authorizationHeader(&cred, %q, %q, %v) =\n      %s\nwant: %s", ot.method, ot.url.String(), ot.form, header, ot.header)
 		}
 	}
 }


### PR DESCRIPTION
Change client to send oauth_verifier and oauth_callback in the
authorization header as described in the RFC. Previous to this change,
these values were passsed in the form.