### PR TITLE
RequestToken that can use any HTTP method

### DIFF
--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -475,14 +475,16 @@ func (c *Client) SetAuthorizationHeader(header http.Header, credentials *Credent
 }
 
 func (c *Client) do(client *http.Client, urlStr string, r *request) (*http.Response, error) {
-	req, err := http.NewRequest(r.method, urlStr, nil)
+	var body io.Reader
+	if r.method != http.MethodGet {
+		body = strings.NewReader(r.form.Encode())
+	}
+	req, err := http.NewRequest(r.method, urlStr, body)
 	if err != nil {
 		return nil, err
 	}
 	if r.method == http.MethodGet {
 		req.URL.RawQuery = r.form.Encode()
-	} else {
-		req.Body = ioutil.NopCloser(strings.NewReader(r.form.Encode()))
 	}
 	for k, v := range c.Header {
 		req.Header[k] = v

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -524,7 +524,9 @@ func (c *Client) Put(client *http.Client, credentials *Credentials, urlStr strin
 }
 
 func (c *Client) requestCredentials(client *http.Client, u string, r *request) (*Credentials, url.Values, error) {
-	r.method = "POST"
+	if r.method == "" {
+		r.method = "POST"
+	}
 	resp, err := c.do(client, u, r)
 	if err != nil {
 		return nil, nil, err
@@ -565,6 +567,11 @@ func (c *Client) RequestTemporaryCredentials(client *http.Client, callbackURL st
 // credentials.
 func (c *Client) RequestToken(client *http.Client, temporaryCredentials *Credentials, verifier string) (*Credentials, url.Values, error) {
 	return c.requestCredentials(client, c.TokenRequestURI, &request{credentials: temporaryCredentials, verifier: verifier})
+}
+
+// RequestTokenAnyMethod is a RequestToken that can use any http method.
+func (c *Client) RequestTokenAnyMethod(client *http.Client, temporaryCredentials *Credentials, verifier, method string) (*Credentials, url.Values, error) {
+	return c.requestCredentials(client, c.TokenRequestURI, &request{credentials: temporaryCredentials, verifier: verifier, method: method})
 }
 
 // RequestTokenXAuth requests token credentials from the server using the xAuth protocol.

--- a/oauth/oauth_test.go
+++ b/oauth/oauth_test.go
@@ -261,31 +261,6 @@ func TestNonce(t *testing.T) {
 	}
 }
 
-func TestRequestTokenAnyMethod(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			t.Errorf("http method for %s want %s", r.Method, http.MethodGet)
-		}
-		v := url.Values{}
-		v.Set("oauth_token", "token")
-		v.Set("oauth_token_secret", "secret")
-		io.WriteString(w, v.Encode())
-	}))
-	defer ts.Close()
-
-	c := Client{TokenRequestURI: ts.URL}
-	cred, _, err := c.RequestTokenAnyMethod(http.DefaultClient, &Credentials{}, "", http.MethodGet)
-	if err != nil {
-		t.Errorf("returned error %v", err)
-	}
-	if cred.Token != "token" {
-		t.Errorf("token for %s want %s", cred.Token, "token")
-	}
-	if cred.Secret != "secret" {
-		t.Errorf("secret for %s want %s", cred.Secret, "secret")
-	}
-}
-
 func TestRequestToken(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -299,6 +274,31 @@ func TestRequestToken(t *testing.T) {
 	defer ts.Close()
 
 	c := Client{TokenRequestURI: ts.URL}
+	cred, _, err := c.RequestToken(http.DefaultClient, &Credentials{}, "")
+	if err != nil {
+		t.Errorf("returned error %v", err)
+	}
+	if cred.Token != "token" {
+		t.Errorf("token for %s want %s", cred.Token, "token")
+	}
+	if cred.Secret != "secret" {
+		t.Errorf("secret for %s want %s", cred.Secret, "secret")
+	}
+}
+
+func TestRequestTokenWithGET(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("http method for %s want %s", r.Method, http.MethodGet)
+		}
+		v := url.Values{}
+		v.Set("oauth_token", "token")
+		v.Set("oauth_token_secret", "secret")
+		io.WriteString(w, v.Encode())
+	}))
+	defer ts.Close()
+
+	c := Client{TokenRequestURI: ts.URL, TokenCredentailsMethod: http.MethodGet}
 	cred, _, err := c.RequestToken(http.DefaultClient, &Credentials{}, "")
 	if err != nil {
 		t.Errorf("returned error %v", err)


### PR DESCRIPTION
Hello!

This PR provides a RequestToken "RequestTokenAnyMethod" that can specify an http method.

I encountered a scenario where I have to do a RequestToken with a GET method in a project that uses OAuth 1.0a.

As a result of survey, it seems that POST is not must.
https://oauth.net/core/1.0a/#rfc.section.6.3.1
> The Service Provider documentation specifies the HTTP method for this request, and HTTP POST is RECOMMENDED.

For example ruby's OAuth 1.0a library can specify methods.
https://github.com/oauth-xx/oauth-ruby/blob/master/lib/oauth/consumer.rb#L212

I care about compatibility and left RequestToken as it was.
If you think that you should fix RequestToken, I obey it.